### PR TITLE
Add configuration save/load banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,11 @@ dependencies with `yarn install`.  There is no backend for this
 project, it just generates the template SVG files directly on the
 frontend.
 
+## Saved Configurations
+
+You can now save and load your dovetail configurations in the UI. Use the
+banner at the top of the application to name a configuration, save it to your
+browser, and reload any saved configuration later.
+
 You can find the current production version of this live at
 [https://dovetails.bieber.dev](https://dovetails.bieber.dev).

--- a/src/App.css
+++ b/src/App.css
@@ -6,12 +6,24 @@
 }
 
 .App-header {
-	min-height: 10vh;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	font-size: calc(10px + 2vmin);
+        min-height: 10vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        font-size: calc(10px + 2vmin);
+}
+
+.ConfigBanner {
+        display: flex;
+        gap: 8px;
+        margin-top: 8px;
+}
+
+.ConfigBanner input,
+.ConfigBanner select,
+.ConfigBanner button {
+        font-size: calc(10px + .5vmin);
 }
 
 .App-header a {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,13 +11,15 @@ import PinCreator from './ui/PinCreator';
 import PinEditor from './ui/PinEditor';
 import Generate from './ui/Generate';
 import Visualizer from './visualize/Visualizer';
+import ConfigBanner from './ui/ConfigBanner';
 
 export default function App() {
 	return (
 		<div className="App">
-			<header className="App-header">
-				Dovetail Generator
-			</header>
+                        <header className="App-header">
+                                <div>Dovetail Generator</div>
+                                <ConfigBanner />
+                        </header>
 			<div className="Body">
 				<div className="BodyLeft">
 					<GlobalSettings />

--- a/src/context/store.tsx
+++ b/src/context/store.tsx
@@ -18,12 +18,12 @@ import type {GuidesAction} from './guides';
 import type {HalfPinsAction} from './halfPins';
 import type {PinsAction} from './pins';
 
-const StoreSchema = z.object(
-	{
-		general: ContextGeneralSchema,
-		guides: ContextGuidesSchema,
-		halfPins: ContextHalfPinsSchema,
-		pins: ContextPinsSchema,
+export const StoreSchema = z.object(
+        {
+                general: ContextGeneralSchema,
+                guides: ContextGuidesSchema,
+                halfPins: ContextHalfPinsSchema,
+                pins: ContextPinsSchema,
 	},
 );
 export type Store = z.infer<typeof StoreSchema>;
@@ -35,7 +35,8 @@ const initStore = {
 	pins: initPins,
 };
 
-type Action = GeneralAction | GuidesAction | HalfPinsAction | PinsAction;
+type LoadAction = {store: 'all', type: 'load', state: Store};
+type Action = GeneralAction | GuidesAction | HalfPinsAction | PinsAction | LoadAction;
 
 type TContext = [Store, React.Dispatch<Action>]
 const Context = createContext<TContext>([initStore, () => {}]);
@@ -45,7 +46,11 @@ const VALIDATIONS = [
 ];
 
 export function useStore(): TContext {
-	return useContext(Context);
+        return useContext(Context);
+}
+
+export function loadStore(state: Store): LoadAction {
+        return {store: 'all', type: 'load', state};
 }
 
 type Props = {children: React.ReactNode | React.ReactNode[]};
@@ -68,12 +73,15 @@ export function StoreProvider({children}:  Props) {
 		(state: Store, action: Action) => {
 			let newState = state;
 
-			switch (action.store) {
-				case 'general':
-					newState = {
-						...state,
-						general: reduceGeneral(state.general, action),
-					};
+                        switch (action.store) {
+                                case 'all':
+                                        newState = action.state;
+                                        break;
+                                case 'general':
+                                        newState = {
+                                                ...state,
+                                                general: reduceGeneral(state.general, action),
+                                        };
 					break;
 				case 'guides':
 					newState = {

--- a/src/ui/ConfigBanner.tsx
+++ b/src/ui/ConfigBanner.tsx
@@ -1,0 +1,77 @@
+import {useEffect, useState} from 'react';
+import {useStore, loadStore, StoreSchema, Store} from '../context/store';
+
+const STORAGE_KEY = 'savedConfigs';
+
+function loadConfigs(): Record<string, Store> {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+        try {
+            const parsed = JSON.parse(saved);
+            // validate each store
+            const valid: Record<string, Store> = {};
+            for (const [name, value] of Object.entries(parsed)) {
+                try {
+                    valid[name] = StoreSchema.parse(value);
+                } catch {
+                    // ignore invalid entry
+                }
+            }
+            return valid;
+        } catch {
+            return {};
+        }
+    }
+    return {};
+}
+
+function saveConfigs(configs: Record<string, Store>) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(configs));
+}
+
+export default function ConfigBanner() {
+    const [store, dispatch] = useStore();
+    const [configs, setConfigs] = useState<Record<string, Store>>({});
+    const [selected, setSelected] = useState('');
+    const [name, setName] = useState('');
+
+    useEffect(() => {
+        setConfigs(loadConfigs());
+    }, []);
+
+    function saveCurrent() {
+        if (!name) return;
+        const newConfigs = {...configs, [name]: store};
+        setConfigs(newConfigs);
+        saveConfigs(newConfigs);
+        setName('');
+    }
+
+    function loadSelected() {
+        const config = configs[selected];
+        if (config) {
+            dispatch(loadStore(config));
+        }
+    }
+
+    const options = Object.keys(configs).map((n, i) => (
+        <option key={i} value={n}>{n}</option>
+    ));
+
+    return (
+        <div className="ConfigBanner">
+            <input
+                type="text"
+                placeholder="Config name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+            />
+            <button onClick={saveCurrent}>Save</button>
+            <select value={selected} onChange={(e) => setSelected(e.target.value)}>
+                <option value="" disabled>Select saved...</option>
+                {options}
+            </select>
+            <button onClick={loadSelected} disabled={!selected}>Load</button>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add instructions on saving configurations
- create ConfigBanner component and styles
- load/save store with new action
- mount banner in header

## Testing
- `yarn test --watchAll=false --passWithNoTests`
- `yarn lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68439c5fa974832cbff8c51464d03c22